### PR TITLE
Fix some compiler warnings and test logic

### DIFF
--- a/pyDNase/footprinting/WellingtonC.h
+++ b/pyDNase/footprinting/WellingtonC.h
@@ -188,7 +188,7 @@ struct tuple2 * wellington(unsigned int const * const f,  unsigned int const * c
 				unsigned const int xBackward = b_bindingArray[i+halffpround+1];
 				unsigned const int nBackward = xBackward + rv_fpscores[i-halffpround];
 
-				if (xForward > 0 & xBackward > 0)
+				if (xForward > 0 && xBackward > 0)
 				{
 					float const p = (float)shoulder / (shoulder + fp_size);
 					float const score = bdtrc(xForward - 1, nForward, p) + bdtrc(xBackward - 1, nBackward, p);
@@ -238,7 +238,7 @@ struct tuple2 * wellington1D(unsigned int const * const f,  unsigned int const *
 				unsigned const int xBackward = b_bindingArray[i+halffpround+1];
 				unsigned const int nBackward = xBackward + rv_fpscores[i-halffpround];
 
-				if (xForward > 0 & xBackward > 0)
+				if (xForward > 0 && xBackward > 0)
 				{
 					float const p = (float)(shoulder*2) / ((shoulder*2) + fp_size);
 					float const score = bdtrc(xForward + xBackward - 1, nForward + nBackward, p);
@@ -367,7 +367,7 @@ struct tuple2 * diff_wellington(unsigned int const * const f,  unsigned int cons
 
 //        float t_score = 0.0;
 //
-//        if (xForwardt > 0 & xBackwardt > 0)
+//        if (xForwardt > 0 && xBackwardt > 0)
 //        {
 //            float const p = (float)shoulder / (shoulder + fp_size);
 //            t_score = bdtrc(xForwardt - 1, nForwardt, p) + bdtrc(xBackwardt - 1, nBackwardt, p);
@@ -395,7 +395,7 @@ struct tuple2 * diff_wellington(unsigned int const * const f,  unsigned int cons
 
             float prior_score;
 
-            if (xForward > 0 & xBackward > 0)
+            if (xForward > 0 && xBackward > 0)
             {
                 const float p = (float)shoulder / (shoulder + fp_size);
                 prior_score = bdtrc(xForward - 1, nForward, p) + bdtrc(xBackward - 1, nBackward, p);
@@ -417,7 +417,7 @@ struct tuple2 * diff_wellington(unsigned int const * const f,  unsigned int cons
                 unsigned const int nForward  = slice(t_f2,0,shoulder + fp_size);
                 unsigned const int xBackward = slice(t_r2,shoulder + fp_size,shoulder + shoulder + fp_size);
                 unsigned const int nBackward = slice(t_r2,shoulder,shoulder + shoulder + fp_size);
-                if (xForward > 0 & xBackward > 0)
+                if (xForward > 0 && xBackward > 0)
                 {
                     float const p = (float)shoulder / (shoulder + fp_size);
                     bootstrap_score[i] = bdtrc(xForward - 1, nForward, p) + bdtrc(xBackward - 1, nBackward, p);

--- a/pyDNase/scripts/dnase_average_profile.py
+++ b/pyDNase/scripts/dnase_average_profile.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import pyDNase
 import numpy as np

--- a/pyDNase/scripts/dnase_bias_estimator.py
+++ b/pyDNase/scripts/dnase_bias_estimator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os, argparse, tempfile, operator, pickle
 from collections import defaultdict
 import pybedtools, pysam

--- a/pyDNase/scripts/dnase_cut_counter.py
+++ b/pyDNase/scripts/dnase_cut_counter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import pyDNase
 from clint.textui import progress, puts

--- a/pyDNase/scripts/dnase_ddhs_scorer.py
+++ b/pyDNase/scripts/dnase_ddhs_scorer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import pyDNase
 import math

--- a/pyDNase/scripts/dnase_fos_scorer.py
+++ b/pyDNase/scripts/dnase_fos_scorer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import pyDNase
 from clint.textui import progress

--- a/pyDNase/scripts/dnase_pretty_picture.py
+++ b/pyDNase/scripts/dnase_pretty_picture.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 __author__ = "Jason Piper"
 
 """

--- a/pyDNase/scripts/dnase_to_JSON.py
+++ b/pyDNase/scripts/dnase_to_JSON.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, pyDNase
 from clint.textui import puts, progress
 parser = argparse.ArgumentParser(description='Writes a JSON file of DNase I cuts for regions from a BED file')

--- a/pyDNase/scripts/dnase_to_javatreeview.py
+++ b/pyDNase/scripts/dnase_to_javatreeview.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, pyDNase, csv, random
 import numpy as np
 from clint.textui import puts, progress

--- a/pyDNase/scripts/dnase_wig_tracks.py
+++ b/pyDNase/scripts/dnase_wig_tracks.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 from clint.textui import progress, puts
 import pyDNase

--- a/pyDNase/scripts/wellington_bootstrap.py
+++ b/pyDNase/scripts/wellington_bootstrap.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import pyDNase, pyDNase.footprinting
 import numpy as np
 from clint.textui import progress

--- a/pyDNase/scripts/wellington_footprints.py
+++ b/pyDNase/scripts/wellington_footprints.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import multiprocessing as mp
 import argparse, os
 from clint.textui import progress, puts_err

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
 
     install_requires=[
         # Not enforcing versions for numpy as it can be a bitch to upgrade
+        "Cython",
         "numpy", # Tested on >=1.5.0
         "matplotlib < 2.0.0", # mpl > 2.0 only works on py3
         "pysam >= 0.8.1",


### PR DESCRIPTION
This resolves some compiler warnings that I noticed while making a bioconda recipe for this package. `&` is used a few places in Wellington where `&&` is quite likely meant instead. Note that `&` has a higher precedence than `>=` and other such comparison operators. So there were a few cases in the code where you were testing for things like `if(some_value > 0 > 0)`, which is unlikely to be what you meant.